### PR TITLE
fix: issue with setting notFound in merged server side/static fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "https://github.com/platypusrex/next-merge-props/issues"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/next-merge-props.esm.js",
@@ -35,7 +35,7 @@
     "prepare": "tsdx build"
   },
   "peerDependencies": {
-    "next": "10.x"
+    "next": ">=10.x"
   },
   "husky": {
     "hooks": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ import {
 export type AnyObject = Record<string, any>;
 export type ResolutionType = 'parallel' | 'sequential';
 export type Context = GetServerSidePropsContext | GetStaticPropsContext;
-export type PropsResult<P> =
+export type PropsResult<P = AnyObject> =
   | GetServerSidePropsResult<P>
   | GetStaticPropsResult<P>;
 export type NextDataFunction = GetServerSideProps | GetStaticProps;

--- a/src/utils/mergeResults.ts
+++ b/src/utils/mergeResults.ts
@@ -19,15 +19,13 @@ export const mergeResults = <P = AnyObject>(
   debug = false
 ): PropsResult<P> => {
   const result = results.find(
-    result => (result as NextRedirectResult).redirect
+    result =>
+      (result as NextRedirectResult).redirect ??
+      (result as NextRedirectResult).notFound
   ) as NextRedirectResult;
+
   if (result?.redirect) {
-    return {
-      redirect: result.redirect,
-      ...(result.revalidate !== undefined
-        ? { revalidate: result.revalidate }
-        : {}),
-    };
+    return { redirect: result.redirect };
   }
 
   if (result?.notFound) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -24,6 +24,42 @@ export const getServerSideBarProps = async (): Promise<PropsResult<
   };
 };
 
+export const getStaticFooProps = async (): Promise<PropsResult<
+  GetServerSideFooProps
+>> => {
+  return {
+    props: {
+      foo: 'foo',
+    },
+    revalidate: 60,
+  };
+};
+
+export const getStaticBarProps = async (): Promise<PropsResult<
+  GetServerSideBarProps
+>> => {
+  return {
+    props: {
+      bar: 'bar',
+    },
+  };
+};
+
+export const getServerSideRedirectProps = async (): Promise<PropsResult> => {
+  return {
+    redirect: {
+      destination: '/',
+      permanent: false,
+    },
+  };
+};
+
+export const getServerSideNotFoundProps = async (): Promise<PropsResult> => {
+  return {
+    notFound: true,
+  };
+};
+
 export const getServerSideUserProps = ({
   onSuccess,
 }: {


### PR DESCRIPTION
This should fix outstanding issue of returning `notFound` from server side or static function and this not resulting in a 404. Since the initial merge to add support for redirects/notFound was done in haste I've also added some proper testing of the both redirect/notFound/revalidation.